### PR TITLE
add npm script for mocker command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6879,6 +6879,12 @@
       "dev": true,
       "optional": true
     },
+    "es6-object-assign": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
+      "dev": true
+    },
     "escape-goat": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
@@ -11818,6 +11824,15 @@
         "picomatch": "^2.2.1"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "regenerate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
@@ -12568,6 +12583,28 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
       "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
+    },
+    "shx": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.2.tgz",
+      "integrity": "sha512-aS0mWtW3T2sHAenrSrip2XGv39O9dXIFUqxAEWHEOS1ePtGIBavdPJY1kE2IHl14V/4iCbUiNDPGdyYTtmhSoA==",
+      "dev": true,
+      "requires": {
+        "es6-object-assign": "^1.0.3",
+        "minimist": "^1.2.0",
+        "shelljs": "^0.8.1"
+      }
     },
     "signal-exit": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "prettier": "^2.0.5",
     "sass": "^1.26.7",
     "sass-loader": "^8.0.2",
+    "shx": "^0.3.2",
     "style-loader": "^1.2.1",
     "tree-kill": "1.2.2",
     "typescript": "^3.9.2",
@@ -106,7 +107,13 @@
     "postinstall": "electron-rebuild",
     "rebuild:electron": "run-s electron-builder-install electron-rebuild",
     "rebuild:node": "npm rebuild",
-    "release": "run-s test build"
+    "release": "run-s test build",
+    "mocker": "run-s mocker:make rebuild:node mocker:folder mocker:help",
+    "mocker:make": "git branch test-0 && git switch test-0",
+    "mocker:folder": "shx mkdir -p DanmakuTree/config && shx mkdir -p DanmakuTree/data && shx mkdir -p DanmakuTree/log",
+    "mocker:help": "echo Please run (in your command line): git cherry-pick (git merge-base master mocker)..mocker && echo HINT: Make sure you run mocker:folder before you run mocker:debug",
+    "mocker:debug": "node --inspect -r esm",
+    "mocker:clean": "git branch -D test-0"
   },
   "version": "0.0.1"
 }


### PR DESCRIPTION
在开发平台 API 的时候，可以通过替换 Electron 依赖的部分，直接从支持 esm 的 node 启动 Services 并且调试和调用，方便开发

具体的 Mock 替换的文件部分见 [mocker](https://github.com/DanmakuTree/DanmakuTree/tree/mocker) 分支的 commits. 或者手动执行 `git cherry-pick (git merge-base master mocker)..mocker`

而完整的使用方法是（从你想要测试的分支开始）：
```
....
npm run mocker
git cherry-pick (git merge-base master mocker)..mocker
npm run mocker:debug
....
git switch master
npm run mocker:clean
```