### PR TITLE
add ElectronMock with conditional require/import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5905,6 +5905,58 @@
         "sha.js": "^2.4.8"
       }
     },
+    "cross-env": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
+      "integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "babel-preset-env": "^1.7.0",
     "chalk": "^4.0.0",
     "copy-webpack-plugin": "^6.0.3",
+    "cross-env": "^7.0.2",
     "css-loader": "^3.5.3",
     "deepmerge": "^4.2.2",
     "electron": "^8.3.1",
@@ -117,7 +118,7 @@
     "mocker:make": "git branch test-0 && git switch test-0",
     "mocker:folder": "shx mkdir -p DanmakuTree/config && shx mkdir -p DanmakuTree/data && shx mkdir -p DanmakuTree/log",
     "mocker:help": "echo Please run (in your command line): git cherry-pick (git merge-base master mocker)..mocker && echo HINT: Make sure you run mocker:folder before you run mocker:debug",
-    "mocker:debug": "node --inspect -r esm",
+    "mocker:debug": "cross-env NODE_ENV=development node --inspect -r esm",
     "mocker:clean": "git branch -D test-0"
   },
   "version": "0.0.1"

--- a/src/main/Consts.js
+++ b/src/main/Consts.js
@@ -1,6 +1,6 @@
 import path from 'path'
 import { version as ProgramVersion } from '../../package.json'
-import { app } from 'electron'
+import { app } from './ElectronMock'
 export const isDev = process.env.NODE_ENV === 'development'
 export const isDebug = process.argv.includes('--debug')
 export const version = ProgramVersion

--- a/src/main/ElectronMock.js
+++ b/src/main/ElectronMock.js
@@ -1,0 +1,40 @@
+/* This modulue intend to mock the following statement:
+ *
+ * import { app } from 'electron'
+ *
+ * and
+ *
+ * import { session } from 'electron'
+ *
+ * because when running the `./Platform` code in pure node.js environment,
+ * there'll be no 'electron' to import from, and that break the code.
+ *
+ * by using isDev = process.env.NODE_ENV === 'development', and use `require` instead of `import`
+ * the intentional design might work. Let's hope!
+ *
+ * NOTE: as well, on Windows it need `cross-env` as dev-dependency to set the NODE_ENV
+*/
+
+const isDev = process.env.NODE_ENV === 'development'
+
+var _app = {}
+_app.pathKV = { 'appData': '.' }
+_app.setPath = function (key, value) { _app.pathKV[key] = value }
+_app.getPath = function (key) { return _app.pathKV[key] }
+
+var _session = {}
+_session.defaultSession = {}
+_session.defaultSession.clearStorageData = console.log
+
+let _appElectron
+let _sessionElectron
+
+if (!isDev) {
+  _appElectron = require('electron').app
+  _sessionElectron = require('electron').session
+}
+
+export const appMock = isDev ? _app : 404
+export const app = isDev ? _app : _appElectron
+export const sessionMock = isDev ? _session : 404
+export const session = isDev ? _session : _sessionElectron

--- a/src/main/Platform/BiliBili/API.js
+++ b/src/main/Platform/BiliBili/API.js
@@ -5,7 +5,7 @@ import { isDev } from '../../Consts'
 import BiliBiliConsts from './Consts'
 import { WebInterfaceBase } from '../../WebInterfaceBase'
 import { KVTable } from '../../KVTable'
-import { session } from 'electron'
+import { session } from '../../ElectronMock'
 // import { promises as fspromise } from 'fs'
 // const readFile = fspromise.readFile
 // const writeFile = fspromise.writeFile


### PR DESCRIPTION
在通过`node -r esm`来调用源代码进行后端开发的时候，常常会由于缺少`'electron'`而无法调用。之前的临时解决方法是将需要修改的两行代码代码放在`mocker`分支上，然后在开发时开新分支进行 cherry-pick https://github.com/DanmakuTree/DanmakuTree/commit/3cfe238e197df13549cb503b13634efe090f8ac8 来实现在`test-0`分支上进行代码的硬修改，示意如下：
```
- import { app } from 'electron'
+ app = appMockObj
...

- import { session } from 'electron'
+ session = sessionMockObj
```

缺点：待编辑补充

而现在设计了新的`ElectronMock.js`用来替代`import { app } from 'electron'`和`import { session } from 'electron'`

新的使用方法：待编辑补充