### PR TITLE
use a more stable API to get danmu WSS-conn config

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -47,7 +47,7 @@ jobs:
 # -a---           5/27/2020 10:12 AM            350 latest.yml
     # ubuntu-latest artifacts, include:  
       # Run ls build
-      # DanmakuTree-0.0.1.AppImage       √
+      # DanmakuTree-0.0.1.AppImage       x
       # danmaku-tree-0.0.1.7z            √
       # danmaku-tree_0.0.1_amd64.deb
       # latest-linux.yml
@@ -62,7 +62,7 @@ jobs:
       # .exe for windows                 √
           # DanmakuTree 0.0.1.exe        .
           # DanmakuTree Setup 0.0.1.exe  x
-      # .AppImage for ubuntu             √
+      # .AppImage for ubuntu             x
           # DanmakuTree-0.0.1.AppImage   .
     - name: Upload .7z file (if any exists)
       uses: actions/upload-artifact@v2
@@ -81,9 +81,9 @@ jobs:
       with:
         name: ${{ matrix.os }}.exe
         path: build/*.exe    # TODO: should exclude the setup .exe
-    - name: Upload .AppImage file (if any exists)
-      if: ${{ runner.os == 'Linux' }}
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ matrix.os }}.AppImage
-        path: build/*.AppImage  
+    # - name: Upload .AppImage file (if any exists)
+    #   if: ${{ runner.os == 'Linux' }}
+    #   uses: actions/upload-artifact@v2
+    #   with:
+    #     name: ${{ matrix.os }}.AppImage
+    #     path: build/*.AppImage  

--- a/src/main/Platform/BiliBili/API.js
+++ b/src/main/Platform/BiliBili/API.js
@@ -29,7 +29,7 @@ export class API extends WebInterfaceBase {
       'getAreaList', 'getMyChooseArea', 'getCoverList', 'setCover', 'getTitleList', 'getMyInfo', 'getReleation',
       'getLiverCustomTags', 'setLiverCustomTags', 'updateRoomInfo', 'getUserInfoNav', 'getFollowingList', 'getFollowersList',
       'setRoomTitle', 'setRoomArea', 'startLive', 'stopLive', 'getUserCard', 'getUserLiveCard', 'getInfoByRoom', 'getRoomInfoByUid',
-      'getDanmuConf', 'getRtmpStream', 'getInfoByUser', 'getRoomGiftList', 'getGiftConfig', 'getWebSevenRank',
+      'getDanmuInfo', 'getRtmpStream', 'getInfoByUser', 'getRoomGiftList', 'getGiftConfig', 'getWebSevenRank',
       'getWebGuardRank', 'getWebMedalRank', 'getRoomInfo', 'getRoomAdminByRoom', 'getRoomAdminByAnchor', 'sendRoomMessage', 'blockRoomUser',
       'removeRoomBlockUserByUid', 'getRoomAdminByUid', 'getBlockUserListBySearch', 'addRoomAdmin', 'removeRoomAdmin',
       'getDanmuReportReasonList', 'reportDanmaku', 'getSuperChatReportReasonList', 'reportSuperChatMessage', 'removeSuperChatMessage', 'setDanmuColor',
@@ -654,19 +654,23 @@ export class API extends WebInterfaceBase {
   /**
    * 获取弹幕链接设置
    * web接口，支持app，但应用困难
-   * @param {Number} roomId 房间号
-   * @param {String} platform 平台
-   * @param {String} player 播放器
+   * @param {Number} roomId 房间号  // not used anymore
+   * @param {String} platform 平台 // not used anymore
+   * @param {String} player 播放器 // not used anymore
+   *
+   * @param {Number} roomId as id
+   * In the future, clients of this api should use `res.data.host_list` to find the wss port
+   * However, here we provide utility access to `res.data.host_server_list` the same as `res.data.host_list`
    */
-  async getDanmuConf (roomId, platform = 'pc', player = 'web') {
+  async getDanmuInfo (roomId) {
     const data = {
-      room_id: roomId,
-      platform: platform,
-      player
+      id: roomId
     }
-    return (await this.webAxios.get('/room/v1/Danmu/getConf', {
+    var res = (await this.webAxios.get('/xlive/web-room/v1/index/getDanmuInfo', {
       params: new URLSearchParams(data)
     })).data
+    res.data.host_server_list = res.data.host_list
+    return res
   }
 
   /**

--- a/src/main/Platform/BiliBili/Services/DanmakuService/index.js
+++ b/src/main/Platform/BiliBili/Services/DanmakuService/index.js
@@ -36,7 +36,7 @@ export class DanmakuService extends WebInterfaceBase {
     var connection = new RoomConnection(roomId)
     this.listen(connection)
     this.rooms.push(connection)
-    API.getDanmuConf(roomId).then((res) => {
+    API.getDanmuInfo(roomId).then((res) => {
       if (res.code === 0) {
         var address = `wss://${res.data.host_server_list[0].host}:${res.data.host_server_list[0].wss_port}/sub`
         connection.connect(roomId, API.uid, res.data.token, address)
@@ -127,7 +127,7 @@ export class DanmakuService extends WebInterfaceBase {
           var target = this.reconnectList.shift()
           var connection = this.rooms.find((v) => { return v.roomId === target })
           if (connection != null && connection.status === 'waitConfig' && !connection.shouldClose) {
-            API.getDanmuConf(target).then((res) => {
+            API.getDanmuInfo(target).then((res) => {
               if (res.code === 0) {
                 if (connection.status === 'waitConfig' && !connection.shouldClose) {
                   var address = `wss://${res.data.host_server_list[0].host}:${res.data.host_server_list[0].wss_port}/sub`


### PR DESCRIPTION
如果有一天我问你：
```
问：你家门在哪里？
你说：我家信箱在这里啊！
```
这就是B站API https://api.live.bilibili.com/room/v1/Danmu/getConf?room_id=102958 和 https://api.live.bilibili.com/xlive/web-room/v1/index/getDanmuInfo?id=102958 对此问题应答的区别。

API也不是不响应，也不是不应答，也不是不告诉你 TCP 和 WS 连接的端口，但是当你问，那么我要找 WSS 连接呢？你说，443！443！答案是 443啊！

![I(7 NTODRP~WP(G%B RJW_M](https://user-images.githubusercontent.com/8946060/216662842-f6bdf2c2-0a6f-4e50-8617-c25d48df044a.jpg)
晕了

附图（请求出问题的对比）：
![VFQ)M3(XFBEWC6JQEQ%G%Y3](https://user-images.githubusercontent.com/8946060/216663257-1b9aeeea-bdc7-4994-9978-1f0ec12ded0c.jpg)
